### PR TITLE
fix BasicCrudIntegrationTests.NativeQueryTests.testNativeGroup by creating a JDBC workflow for native query

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/BasicCrudIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/BasicCrudIntegrationTests.java
@@ -17,6 +17,7 @@
 package com.mongodb.hibernate;
 
 import static com.mongodb.hibernate.MongoTestAssertions.assertEq;
+import static com.mongodb.hibernate.MongoTestAssertions.assertIterableEq;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mongodb.client.MongoCollection;
@@ -219,9 +220,9 @@ class BasicCrudIntegrationTests implements SessionFactoryScopeAware {
 
             sessionFactoryScope.inTransaction(session -> session.persist(book));
             BookSummary loadedBookSummary = sessionFactoryScope.fromTransaction(
-                    session -> session.createQuery("SELECT author, title FROM book", BookSummary.class)
+                    session -> session.createQuery("SELECT author, title FROM Book", BookSummary.class)
                             .getSingleResult());
-            assertEq(book, loadedBookSummary);
+            assertThat(loadedBookSummary).usingRecursiveComparison().ignoringFields("id").isEqualTo(book);
         }
     }
 
@@ -300,7 +301,7 @@ class BasicCrudIntegrationTests implements SessionFactoryScopeAware {
         assertThat(mongoCollection.find()).containsExactly(expectedDoc);
     }
 
-    @Entity
+    @Entity(name = "Book")
     @Table(name = "books")
     static class Book {
         @Id
@@ -324,8 +325,12 @@ class BasicCrudIntegrationTests implements SessionFactoryScopeAware {
     }
 
     static class BookSummary {
-        String title;
         String author;
+        String title;
+        public BookSummary(String author, String title) {
+            this.author = author;
+            this.title = title;
+        }
     }
 
     @Entity

--- a/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
+++ b/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
@@ -23,10 +23,10 @@ public final class MongoConstants {
 
     private MongoConstants() {}
 
-    public static final JsonWriterSettings EXTENDED_JSON_WRITER_SETTINGS =
-            JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED)
-                    .undefinedConverter((bsonUndefined, strictJsonWriter) -> strictJsonWriter.writeRaw("?"))
-                    .build();
+    public static final JsonWriterSettings EXTENDED_JSON_WRITER_SETTINGS = JsonWriterSettings.builder()
+            .outputMode(JsonMode.EXTENDED)
+            .undefinedConverter((bsonUndefined, strictJsonWriter) -> strictJsonWriter.writeRaw("?"))
+            .build();
 
     public static final String MONGO_DBMS_NAME = "MongoDB";
     public static final String MONGO_JDBC_DRIVER_NAME = "MongoDB Java Driver JDBC Adapter";

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -79,14 +79,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import org.bson.BsonUndefined;
-import org.bson.json.Converter;
-import org.bson.json.JsonMode;
 import org.bson.BsonValue;
 import org.bson.json.JsonWriter;
-import org.bson.json.JsonWriterSettings;
-import org.bson.json.StrictJsonWriter;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.Stack;
 import org.hibernate.persister.entity.EntityPersister;

--- a/src/main/java/com/mongodb/hibernate/internal/type/ValueConversions.java
+++ b/src/main/java/com/mongodb/hibernate/internal/type/ValueConversions.java
@@ -100,7 +100,7 @@ public final class ValueConversions {
         return new BsonObjectId(value);
     }
 
-    static Object toDomainValue(BsonValue value) throws SQLFeatureNotSupportedException {
+    public static Object toDomainValue(BsonValue value) throws SQLFeatureNotSupportedException {
         assertNotNull(value);
         if (value instanceof BsonBoolean v) {
             return toDomainValue(v);

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoParameterRecognizer.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoParameterRecognizer.java
@@ -47,7 +47,7 @@ class MongoParameterRecognizer {
                     } else if (c == '$' || c == '_' || Character.isLetter(c)) {
                         i = scanUnquotedString(c, i, json, builder);
                     } else {
-                        builder.append(c);  // or throw exception, as this isn't valid JSON
+                        builder.append(c); // or throw exception, as this isn't valid JSON
                     }
             }
         }
@@ -65,7 +65,8 @@ class MongoParameterRecognizer {
         return i - 1;
     }
 
-    private static int scanUnquotedString(final char firstCharacter, final int startIndex, final String json, final StringBuilder builder) {
+    private static int scanUnquotedString(
+            final char firstCharacter, final int startIndex, final String json, final StringBuilder builder) {
         builder.append(firstCharacter);
         int i = startIndex;
         char c = json.charAt(i++);
@@ -76,7 +77,8 @@ class MongoParameterRecognizer {
         return i - 1;
     }
 
-    private static int scanString(final char quoteCharacter, final int startIndex, final String json, final StringBuilder builder) {
+    private static int scanString(
+            final char quoteCharacter, final int startIndex, final String json, final StringBuilder builder) {
         int i = startIndex;
         builder.append(quoteCharacter);
         while (i < json.length()) {

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoResultSet.java
@@ -46,6 +46,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Objects;
@@ -200,6 +201,19 @@ final class MongoResultSet implements ResultSetAdapter {
     }
 
     @Override
+    public @Nullable Object getObject(int columnIndex) throws SQLException {
+        checkClosed();
+        checkColumnIndex(columnIndex);
+        return getValue(columnIndex, bsonValue -> {
+            try {
+                return ValueConversions.toDomainValue(bsonValue);
+            } catch (SQLFeatureNotSupportedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Override
     public <T> @Nullable T getObject(int columnIndex, Class<T> type) throws SQLException {
         checkClosed();
         checkColumnIndex(columnIndex);
@@ -288,10 +302,34 @@ final class MongoResultSet implements ResultSetAdapter {
             return fieldNames.size();
         }
 
-
         @Override
         public String getColumnLabel(int column) {
             return fieldNames.get(column - 1);
+        }
+
+        @Override
+        public String getColumnTypeName(int column) throws SQLException {
+            return "";
+        }
+
+        @Override
+        public int getPrecision(int column) throws SQLException {
+            return 0;
+        }
+
+        @Override
+        public int getScale(int column) throws SQLException {
+            return 0;
+        }
+
+        @Override
+        public int getColumnDisplaySize(int column) throws SQLException {
+            return 1;
+        }
+
+        @Override
+        public int getColumnType(int column) throws SQLException {
+            return Types.JAVA_OBJECT;
         }
     }
 }

--- a/src/main/java/com/mongodb/hibernate/jdbc/ResultSetAdapter.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/ResultSetAdapter.java
@@ -241,7 +241,7 @@ interface ResultSetAdapter extends ResultSet {
     }
 
     @Override
-    default Object getObject(int columnIndex) throws SQLException {
+    default @Nullable Object getObject(int columnIndex) throws SQLException {
         throw new SQLFeatureNotSupportedException("getObject not implemented");
     }
 


### PR DESCRIPTION
This DRAFT only focuses on fixing the testNativeGroup() testing case, but the approach is generic.

For non-entity native query result class (entity class will work as proved by the other existing testing case without bothering with ResultSetMetadata for internally Hibernate's ResultSetBuilder will be based on the entity class per se), an implicit ResultSetBuilder is required and ResultSetMetada is heavily relied upon, particually the column type (JDBC type code) info, which is used to  dispatch to different ResultSet getXXX() method based on it. Compared to SQL counterpart, it is hard to provide Mongo column-specific type info, so a workaround is relied in this PR as below:

- `java.sql.Types.JAVA_OBJECT` is returned invariably
- this column type will end up with invoking a new JDBC ResultSet's `Object getObject(int columnIndex)` method which is never used by Hibernate.
- return Java object based on existing `ValuesConventions` util class to converse from Bson value to domain value

So basically we create a new native query workflow without conflicting with existing entity workflow, and it seems to work.